### PR TITLE
Update readme for ls and RM commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,45 @@ scrman new my_script --no-link
 scrman new my_script --no-edit
 ```
 
+### List scripts
+
+```bash
+# List all scripts
+scrman ls
+
+# List scripts matching a pattern
+scrman ls my_*
+
+# List scripts for a specific language
+scrman ls --lang python
+
+# List scripts in different output formats
+scrman ls --format json
+scrman ls --format tsv
+scrman ls --format yml
+scrman ls --format csv
+```
+
+### Remove scripts
+
+```bash
+# Remove a script (with confirmation)
+scrman rm my_script
+
+# Remove a script from a specific language
+scrman rm my_script --lang python
+
+# Force remove without confirmation
+scrman rm my_script --force
+```
+
 ### Options
 
 - `-l, --lang LANGUAGE` - Specify the language (ruby, python, javascript, typescript, bash, zsh)
 - `-b, --link` - Link the script to your bin directory (default: true)
 - `-e, --edit` - Open the script in your editor (default: true)
+- `-f, --format FORMAT` - Output format for ls command (tsv, json, yml, csv)
+- `-f, --force` - Force removal without confirmation for rm command
 
 ## Configuration
 


### PR DESCRIPTION
Add documentation for `ls` and `rm` commands to README.md.

---
<a href="https://cursor.com/background-agent?bcId=bc-503ad957-fc45-4888-a3f5-a70b15c3fbbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-503ad957-fc45-4888-a3f5-a70b15c3fbbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

